### PR TITLE
Add concurrent queue for decoding

### DIFF
--- a/Sources/OggDecoderObjC/OGGDecoder.mm
+++ b/Sources/OggDecoderObjC/OGGDecoder.mm
@@ -10,6 +10,7 @@
 #import "OGGDecoder.h"
 
 @implementation OGGDecoder
+dispatch_queue_t _decodeQueue = dispatch_queue_create("com.oggDecoder.decodingQueue", DISPATCH_QUEUE_CONCURRENT);
 
 - (BOOL)decode:(NSURL *)oggFile into:(NSURL *)outputFile {
     oggHelper helper;
@@ -29,7 +30,7 @@
 }
 
 - (void)decode:(NSURL *)oggFile completion:(void (^)(NSURL * _Nullable))completion {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(_decodeQueue, ^{
         NSURL* output = [self decode:oggFile];
         dispatch_async(dispatch_get_main_queue(), ^(void){
             completion(output);
@@ -38,7 +39,7 @@
 }
 
 - (void)decode:(NSURL *)oggFile into:(NSURL *)outputFile completion:(void (^)(BOOL))completion {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(_decodeQueue, ^{
         BOOL result = [self decode:oggFile into:outputFile];
         dispatch_async(dispatch_get_main_queue(), ^(void){
             completion(result);


### PR DESCRIPTION
This PR creates a new queue that is used to decode files. Previous code using main_queue may raise a UI freeze when performing multiple operations simultaneously. 